### PR TITLE
dhcpd: treat EFI BC the same as EFI x86-64

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -842,6 +842,8 @@ EOD;
             if (!empty($dhcpifconf['filename']) && !empty($dhcpifconf['filename32']) && !empty($dhcpifconf['filename64'])) {
                 $dhcpdconf .= "  if option arch = 00:06 {\n";
                 $dhcpdconf .= "    filename \"{$dhcpifconf['filename32']}\";\n";
+                $dhcpdconf .= "  } else if option arch = 00:07 {\n";
+                $dhcpdconf .= "    filename \"{$dhcpifconf['filename64']}\";\n";
                 $dhcpdconf .= "  } else if option arch = 00:09 {\n";
                 $dhcpdconf .= "    filename \"{$dhcpifconf['filename64']}\";\n";
                 $dhcpdconf .= "  } else {\n";


### PR DESCRIPTION
Several vendors use EFI BC instead of the EFI x86-64 value for the arch, some thinkpads for example. We noticed this while we tried to use PXE on all our machines and that some EFI systems with 64-bit didn't work and some did. We then found the old commit that change the if clause from 00:07 to 00:09 and tested around. Thus we found out that some machines use 7 and some 9, so IMHO it's correct to redirect both cases to the 64bit syslinux filename. This commit doesn't break old configs, just adds the additional option.